### PR TITLE
0x0F as EBR too

### DIFF
--- a/libvsmbr/libvsmbr_volume.c
+++ b/libvsmbr/libvsmbr_volume.c
@@ -1153,7 +1153,8 @@ int libvsmbr_internal_volume_read_partition_entries(
 		{
 			continue;
 		}
-		if( partition_entry->type == 0x05 )
+		if( partition_entry->type == 0x05 ||
+			partition_entry->type == 0x0F)
 		{
 			if( extended_partition_record != NULL )
 			{


### PR DESCRIPTION
In order with https://en.wikipedia.org/wiki/Extended_boot_record 0x0F  is type of EBR too.